### PR TITLE
maptestsmall is now DefaultSmall

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 
 teamA=examplefuncsplayer
 teamB=examplefuncsplayer
-maps=maptestsmall
+maps=DefaultSmall
 
 # Some optional configurations you can adjust as you need
 


### PR DESCRIPTION
There appears to be an outdated reference to maptestsmall in gradle.properties that causes `./gradlew run` to throw an error because there is no maptestsmall anymore this year. This PR fixes that.